### PR TITLE
Feature/fix unexported events

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -3,3 +3,4 @@
 ## Latest changes (not yet released)
 
 - Add support for validating access token response signatures
+- Fix unexported event types

--- a/src/openid/middleware.ts
+++ b/src/openid/middleware.ts
@@ -154,7 +154,7 @@ function fail(req: Request, res: Response) {
 
 export namespace middleware {
 
-	export const emitter: EventEmitter = new EventEmitter();
+	export let emitter: EventEmitter = new EventEmitter();
 
 	/**
 	 * Returns an express middleware that checks that an access token

--- a/src/openid/middleware.ts
+++ b/src/openid/middleware.ts
@@ -51,11 +51,11 @@ const BEARER_PREFIX: string = 'Bearer ';
  */
 const HTTP_AUTHORIZATION_HEADER: string = 'Authorization';
 
-export const DENIED_EVENT = 'denied';
+export const EVENT_DENIED = 'denied';
 
-export const GRANT_CHECKED_EVENT = 'grant_checked';
+export const EVENT_GRANT_CHECKED = 'grant_checked';
 
-export const TOKEN_VALIDATED_EVENT = 'token_validated';
+export const EVENT_TOKEN_VALIDATED = 'token_validated';
 
 /**
  * @private
@@ -116,7 +116,7 @@ function setUserOnRequest(req: Request, userInfo: UserInfo) {
 	orizuru.user = user;
 	req.orizuru = orizuru;
 
-	middleware.emitter.emit(TOKEN_VALIDATED_EVENT, `Token validated for: ${req.ip}`);
+	middleware.emitter.emit(EVENT_TOKEN_VALIDATED, `Token validated for: ${req.ip}`);
 
 }
 
@@ -129,7 +129,7 @@ function setGrant(req: Request) {
 
 		(req.orizuru as Orizuru.Context).grantChecked = true;
 
-		middleware.emitter.emit(GRANT_CHECKED_EVENT, `Grant checked for: ${req.ip}`);
+		middleware.emitter.emit(EVENT_GRANT_CHECKED, `Grant checked for: ${req.ip}`);
 
 		return undefined;
 
@@ -144,7 +144,7 @@ function fail(req: Request, res: Response) {
 
 	return (error: Error) => {
 
-		middleware.emitter.emit(DENIED_EVENT, `Access denied to: ${req ? req.ip ? req.ip : 'unknown' : 'unknown'}, error: ${error.message}.`);
+		middleware.emitter.emit(EVENT_DENIED, `Access denied to: ${req ? req.ip ? req.ip : 'unknown' : 'unknown'}, error: ${error.message}.`);
 
 		res.sendStatus(401);
 

--- a/src/openid/middleware.ts
+++ b/src/openid/middleware.ts
@@ -49,22 +49,13 @@ const BEARER_PREFIX: string = 'Bearer ';
 /**
  * @private
  */
-const DENIED_EVENT = 'denied';
-
-/**
- * @private
- */
-const GRANT_CHECKED_EVENT = 'grant_checked';
-
-/**
- * @private
- */
 const HTTP_AUTHORIZATION_HEADER: string = 'Authorization';
 
-/**
- * @private
- */
-const TOKEN_VALIDATED_EVENT = 'token_validated';
+export const DENIED_EVENT = 'denied';
+
+export const GRANT_CHECKED_EVENT = 'grant_checked';
+
+export const TOKEN_VALIDATED_EVENT = 'token_validated';
 
 /**
  * @private


### PR DESCRIPTION
The OpenID middleware has an event emitter but didn't export the types of the events via type definitions. This is just a simple update to correct that.