### PR TITLE
Feature/introspection optional secret

### DIFF
--- a/src/index/client/oauth2.ts
+++ b/src/index/client/oauth2.ts
@@ -356,7 +356,7 @@ export interface IntrospectionParams extends HasClientId {
 	/**
 	 * The client secret for your application.
 	 */
-	clientSecret: string;
+	clientSecret?: string;
 
 }
 


### PR DESCRIPTION
This resolves a breaking type change introduced by the introspection changes. The client secret is still required, an error is thrown if it is not included specifically for the introspection:

https://github.com/financialforcedev/orizuru-auth/blob/master/src/index/client/oauth2.ts#L672