### PR TITLE
Feature/update token middleware

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -6,6 +6,7 @@
 
 - Support [token introspection](https://tools.ietf.org/html/rfc7662) for both OAuth2 and [Salesforce](https://help.salesforce.com/articleView?id=remoteaccess_oidc_token_introspection.htm)
 - Update the type of the `signingSecret` to allow encrypted keys
+- Add option to grantChecker middleware to add issued access token to context
 
 ### FIXES
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/financialforcedev/orizuru-auth.svg?branch=master)](https://travis-ci.org/financialforcedev/orizuru-auth)
 
-Orizuru authentication is an [Express](http://expressjs.com/)-compatible authentication middleware for [Node.js](http://nodejs.org/). 
+Orizuru authentication is an [Express](http://expressjs.com/)-compatible authentication middleware for [Node.js](http://nodejs.org/).
 
 It is aimed at users of the [Orizuru](https://www.npmjs.com/package/@financialforcedev/orizuru) framework, but can also be used standalone. The authentication process has been tested with Salesforce and Google as Identity Providers, although it should be possible to use it with others.
 
@@ -27,7 +27,7 @@ Orizuru Auth provides a function to initialise the [OAuth 2.0 Web Server Authent
 
 For the examples, the initial configuration has been provided in the `examples` directory of this repository. This can be copied to another directory to be worked with.
 
-Two configuration files should be provided: the `default.json` file which contains any insensitive data (this is included with the source); and the `local.json` configuration file which contains sensitive data. Create a `local.json` file, within the `config` directory with the following contents, where each of the values has been substituted for your Salesforce connected app details. 
+Two configuration files should be provided: the `default.json` file which contains any insensitive data (this is included with the source); and the `local.json` configuration file which contains sensitive data. Create a `local.json` file, within the `config` directory with the following contents, where each of the values has been substituted for your Salesforce connected app details.
 
 ```json
 {
@@ -48,11 +48,11 @@ Two configuration files should be provided: the `default.json` file which contai
 }
 ```
 
-Once completed, the server can be started via `npm start` or in VS Code via the launch configuration. 
+Once completed, the server can be started via `npm start` or in VS Code via the launch configuration.
 
 Changes to the imports are omitted from further examples; assuming VS Code is being used, the examples directory contains the default configuration for automatically optimising imports.
 
-The first example illustrates how the authentication URL generator can be used with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq). A HTTPS server is used with a generated self-signed certificate. 
+The first example illustrates how the authentication URL generator can be used with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq). A HTTPS server is used with a generated self-signed certificate.
 
 The route `https://localhost:8080/api/v1.0/auth` is added to the server. This route redirects the user to the Salesforce login page; it initialises the [OAuth 2.0 Web Server Authentication Flow](https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm).
 
@@ -133,7 +133,7 @@ server.addRoute({
     synchronous: true
 });
 
-/** 
+/**
  * All the code specified in the rest of the readme should be added here.
  */
 
@@ -198,7 +198,7 @@ The token validator middleware checks that a valid OpenID Connect Bearer token e
 
 If the token is successfully validated then a *user* object is set on the request's *orizuru* object.
 
-The following example illustrates how the token validator middleware can be used with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq) to validate tokens contained in the authorization request header. It follows on from the example given in the [Auth Callback](#auth-callback) section. 
+The following example illustrates how the token validator middleware can be used with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq) to validate tokens contained in the authorization request header. It follows on from the example given in the [Auth Callback](#auth-callback) section.
 
 The route `https://localhost:8080/api/auth/v1.0/validateToken` is added to the server as a GET request. If the request is successful, a **token validated** message is printed to the console and the *orizuru* object is returned. Otherwise, a denied message is printed to the console.
 
@@ -276,7 +276,7 @@ This can be called at any time to obtain credentials to connect to Salesforce. I
 
 The credentials returned are in a form suitable to be used with [JSforce](https://jsforce.github.io/).
 
-The following example illustrates how the token granter can be used, with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq), to retrieve the limits for a Salesforce organization. It follows on from the example given in the [Grant Checker](#grant-checker) section. 
+The following example illustrates how the token granter can be used, with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq), to retrieve the limits for a Salesforce organization. It follows on from the example given in the [Grant Checker](#grant-checker) section.
 
 The route `https://localhost:8080/api/v1.0/limits` is added to the server as a GET request. If the request is successful, a JSON response containing the limits is returned. Otherwise, a denied message is printed to the console. It makes use of an Orizuru response writer function, rather than a middleware, to retrieve the limits and send them to the user.
 
@@ -331,7 +331,7 @@ server.addRoute({
 
 The token introspector middleware can be used to determine the active state of an OAuth 2.0 token and retrieve meta-information about this token. It can be used in tandem with either the [Auth Callback](#auth-callback) or the [Token Grantor](#token-granter) middlewares.
 
-The following example illustrates how the token introspector can be used, with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq), to retrieve the token information. It follows on from the example given in the [Token Granter](#token-granter) section. 
+The following example illustrates how the token introspector can be used, with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq), to retrieve the token information. It follows on from the example given in the [Token Granter](#token-granter) section.
 
 The route `https://localhost:8080/api/auth/v1.0/introspectToken` is added to the server as a GET request. If the request is successful, a **token introspected** message is printed to the console and the *orizuru* object is returned. Otherwise, a denied message is printed to the console.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ server.addRoute({
 
 The grant checker is designed to be used in tandem with the token Validator. It uses the `user` object on the request's `orizuru` object and attempts to obtain an OpenID Connect access token using a JWT Bearer grant request. In order for this to work the Identity Provider must have a previously established authorisation for the user requested. With the Salesforce identity provider this is achieved by using a Connected App with an uploaded certificate.
 
-If this completes successfully it sets the `orizuru` object `grantChecked` property to be true, otherwise the user will be refused access.
+If this completes successfully it sets the `orizuru` object `grantChecked` property to be true, otherwise the user will be refused access. The access token can also be directly set on the `orizuru` object by setting the `setTokenOnContext` option to true when creating the middleware.
 
 The following example illustrates how the grant checker can be used, with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq), to validate tokens contained in the authorization request header. It follows on from the example given in the [Token Validator](#token-validator) section.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ server.addRoute({
 
 The grant checker is designed to be used in tandem with the token Validator. It uses the `user` object on the request's `orizuru` object and attempts to obtain an OpenID Connect access token using a JWT Bearer grant request. In order for this to work the Identity Provider must have a previously established authorisation for the user requested. With the Salesforce identity provider this is achieved by using a Connected App with an uploaded certificate.
 
-If this completes successfully it sets the `orizuru` object `grantChecked` property to be true, otherwise the user will be refused access. The access token can also be directly set on the `orizuru` object by setting the `setTokenOnContext` option to true when creating the middleware.
+If this completes successfully it sets the `orizuru` object `grantChecked` property to be true, otherwise the user will be refused access. The access token can also be directly set on the `orizuru` object by setting the `setTokenOnContext` option to true when creating the middleware. Ensure you have adequate security in place to prevent reading or interception of the token.
 
 The following example illustrates how the grant checker can be used, with [Orizuru](https://github.com/financialforcedev/orizuru) and [Orizuru Transport RabbitMQ](https://github.com/financialforcedev/orizuru-transport-rabbitmq), to validate tokens contained in the authorization request header. It follows on from the example given in the [Token Validator](#token-validator) section.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,11 @@ declare global {
 		interface Context {
 
 			/**
+			 * The access token, following the grant check. Optionally added during the grant check.
+			 */
+			accessToken?: string;
+
+			/**
 			 * If true, the grant check has been performed for this user; an access token can be
 			 * retrieved for the user.
 			 */
@@ -181,6 +186,8 @@ export {
 
 export { SalesforceAccessTokenResponse, SalesforceUser } from './index/client/salesforce';
 export { SalesforceIdentity, UserInfo } from './index/client/salesforce/identity';
+
+export { GrantRequestOptions } from './index/middleware/grantChecker';
 
 // Token Grantor types
 export type AuthCodeAccessTokenGrantor = (params: TokenGrantorParams, opts?: GrantOptions) => Promise<AccessTokenResponse>;

--- a/src/index/middleware/grantChecker.ts
+++ b/src/index/middleware/grantChecker.ts
@@ -39,6 +39,9 @@ export interface GrantRequestOptions {
 
 	/**
 	 * Set the token on orizuru context.
+	 *
+	 * WARNING: This option should be used with care;
+	 * make sure that the token is as secure as possible
 	 */
 	setTokenOnContext?: boolean;
 


### PR DESCRIPTION
- Add option to grantChecker middleware to add issued access token to context
  - This is to prevent having to set up a second login to retrieve the token if required.